### PR TITLE
Feat: post와 comment fetch 분리

### DIFF
--- a/backend/controllers/comment.controller.js
+++ b/backend/controllers/comment.controller.js
@@ -20,6 +20,36 @@ const getAllComments = async (req, res) => {
   }
 };
 
+// 특정 게시물의 댓글 조회
+const getCommentsByPostId = async (req, res) => {
+  const { postId } = req.params;
+  try {
+    const comments = await Comment.findAll({
+      where: { postId },
+      include: [
+        {
+          model: User,
+          attributes: ["userId", "userName", "userImage"],
+        },
+        {
+          model: CommentLike,
+          as: "likedUser",
+          attributes: ["userId"],
+          include: [
+            {
+              model: User,
+              attributes: ["userId", "userName", "userImage"],
+            },
+          ],
+        },
+      ],
+    });
+
+    res.status(200).json(comments);
+  } catch (error) {
+    res.status(500).json({ error: "서버 오류" });
+  }
+};
 
 // 댓글 작성
 const createComment = async (req, res) => {
@@ -66,6 +96,7 @@ const deleteComment = async (req, res) => {
 
 module.exports = {
   getAllComments,
+  getCommentsByPostId,
   createComment,
   deleteComment,
 };

--- a/backend/controllers/post.controller.js
+++ b/backend/controllers/post.controller.js
@@ -39,27 +39,6 @@ const getAllPosts = async (req, res) => {
     const posts = await Post.findAll({
       include: [
         {
-          model: Comment,
-          as: "comments",
-          include: [
-            {
-              model: User,
-              attributes: ["userId", "userName", "userImage"],
-            },
-            {
-              model: CommentLike,
-              as: "likedUser",
-              attributes: ["userId"],
-              include: [
-                {
-                  model: User,
-                  attributes: ["userId", "userName", "userImage"],
-                },
-              ],
-            },
-          ],
-        },
-        {
           model: User,
           attributes: ["userId", "userName", "userImage"],
         },
@@ -90,27 +69,6 @@ const getPostById = async (req, res) => {
 
     const post = await Post.findByPk(postId, {
       include: [
-        {
-          model: Comment,
-          as: "comments",
-          include: [
-            {
-              model: User,
-              attributes: ["userId", "userName", "userImage"],
-            },
-            {
-              model: CommentLike,
-              as: "likedUser",
-              attributes: ["userId"],
-              include: [
-                {
-                  model: User,
-                  attributes: ["userId", "userName", "userImage"],
-                },
-              ],
-            },
-          ],
-        },
         {
           model: User,
           attributes: ["userId", "userName", "userImage"],
@@ -164,27 +122,6 @@ const createPost = async (req, res) => {
 
     const completePost = await Post.findByPk(newPost.postId, {
       include: [
-        {
-          model: Comment,
-          as: "comments",
-          include: [
-            {
-              model: User,
-              attributes: ["userId", "userName", "userImage"],
-            },
-            {
-              model: CommentLike,
-              as: "likedUser",
-              attributes: ["userId"],
-              include: [
-                {
-                  model: User,
-                  attributes: ["userId", "userName", "userImage"],
-                },
-              ],
-            },
-          ],
-        },
         {
           model: User,
           attributes: ["userId", "userName", "userImage"],

--- a/backend/routes/api/comment.js
+++ b/backend/routes/api/comment.js
@@ -6,6 +6,9 @@ const commentController = require("../../controllers/comment.controller");
 // 전체 댓글 조회
 router.get("/", commentController.getAllComments);
 
+// 특정 게시물의 댓글 조회
+router.get("/:postId", commentController.getCommentsByPostId);
+
 // 댓글 작성
 router.post("/", verifyToken, commentController.createComment);
 

--- a/frontend/src/Components/Comment/CommentForm/index.styles.tsx
+++ b/frontend/src/Components/Comment/CommentForm/index.styles.tsx
@@ -4,8 +4,8 @@ const CommentFormContainer = styled.form`
   display: flex;
   flex-direction: row;
   align-items: start;
-  margin-top: 20px;
   padding: 10px;
+  border-top: 1px #dddddd solid;
 `;
 
 const CommentContainer = styled.div`

--- a/frontend/src/Components/Comment/CommentForm/index.tsx
+++ b/frontend/src/Components/Comment/CommentForm/index.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch } from "@reduxjs/toolkit";
-import { fetchPostById } from "../../../store/reducers/postSlice";
-import { createComment } from "../../../store/reducers/commentSlice";
+import { createComment, fetchCommentsByPostId } from "../../../store/reducers/commentSlice";
 import { selectAccessToken } from "../../../store/reducers/tokenSlice";
 import Styled from "./index.styles";
 import { BsSendFill } from "react-icons/bs";
@@ -36,7 +35,7 @@ const CommentForm: React.FC<CommentFormProps> = ({ postId }) => {
 
     // 댓글 생성 액션 디스패치
     await dispatch(createComment({ postId, text, token }));
-    await dispatch(fetchPostById(postId));
+    await dispatch(fetchCommentsByPostId(postId));
 
     // 댓글 내용 초기화
     setText("");

--- a/frontend/src/Components/Comment/CommentItem/index.tsx
+++ b/frontend/src/Components/Comment/CommentItem/index.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch } from "@reduxjs/toolkit";
 import Styled from "./index.styles";
 import { selectUser } from "../../../store/reducers/userSlice";
-import { fetchPostById } from "../../../store/reducers/postSlice";
+import { fetchCommentsByPostId } from "../../../store/reducers/commentSlice";
 import { selectAccessToken } from "../../../store/reducers/tokenSlice";
 import { likeComment, unlikeComment } from "../../../store/reducers/likeSlice";
 import moment from "moment";
@@ -39,12 +39,12 @@ const CommentItem: React.FC<CommentsContainerProps> = ({ comment }) => {
 
   const handleLikeComment = async () => {
     await dispatch(likeComment({ commentId, token }));
-    await dispatch(fetchPostById(postId));
+    await dispatch(fetchCommentsByPostId(postId));
   };
 
   const handleUnlikeComment = async () => {
     await dispatch(unlikeComment({ commentId, token }));
-    await dispatch(fetchPostById(postId));
+    await dispatch(fetchCommentsByPostId(postId));
   };
 
   return (

--- a/frontend/src/Components/Comment/Comments/index.tsx
+++ b/frontend/src/Components/Comment/Comments/index.tsx
@@ -7,18 +7,15 @@ import Modal from "../../Modal";
 import CommentsContainer from "../CommentsContainer";
 import CommentForm from "../CommentForm";
 
-import { Comment as CommentData } from "../../../store/reducers/commentSlice";
-
 export interface CommentsContainerProps {
   commentsProps: {
     postId: number;
     commentCount: number;
-    comments: CommentData[];
   };
 }
 
 const Comments: React.FC<CommentsContainerProps> = ({ commentsProps }) => {
-  const { postId, commentCount, comments } = commentsProps;
+  const { postId, commentCount } = commentsProps;
   const countText = commentCount > 0 && `댓글 ${commentCount}개 보기`;
 
   const user = useSelector(selectUser);
@@ -55,7 +52,7 @@ const Comments: React.FC<CommentsContainerProps> = ({ commentsProps }) => {
       {isToastVisible && <Toast toastProps={{ path: "user" }} />}
       {isModalVisible && (
         <Modal onClose={handleCloseModal} modalRef={modalRef}>
-          <CommentsContainer comments={comments} />
+          <CommentsContainer postId={postId} />
           {user && <CommentForm postId={postId} />}
         </Modal>
       )}

--- a/frontend/src/Components/Comment/CommentsContainer/index.tsx
+++ b/frontend/src/Components/Comment/CommentsContainer/index.tsx
@@ -1,13 +1,25 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Styled from "./index.styles";
-import { Comment } from "../../../store/reducers/commentSlice";
+import {
+  fetchCommentsByPostId,
+  selectComments,
+} from "../../../store/reducers/commentSlice";
 import CommentItem from "../CommentItem";
+import { useSelector, useDispatch } from "react-redux";
+import { ThunkDispatch } from "@reduxjs/toolkit";
 
 export interface CommentsContainerProps {
-  comments: Comment[];
+  postId: number;
 }
 
-const CommentsContainer: React.FC<CommentsContainerProps> = ({ comments }) => {
+const CommentsContainer: React.FC<CommentsContainerProps> = ({ postId }) => {
+  const dispatch = useDispatch<ThunkDispatch<any, any, any>>();
+  const comments = useSelector(selectComments);
+
+  useEffect(() => {
+    dispatch(fetchCommentsByPostId(postId));
+  }, []);
+
   return (
     <Styled.CommentContainer>
       {comments?.map((comment) => (

--- a/frontend/src/Components/Post/Icons/index.tsx
+++ b/frontend/src/Components/Post/Icons/index.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useState, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch } from "@reduxjs/toolkit";
 import Styled from "./index.styles";
 import { selectUser } from "../../../store/reducers/userSlice";
 import { fetchPostById } from "../../../store/reducers/postSlice";
-import { Comment as CommentData } from "../../../store/reducers/commentSlice";
 import { selectAccessToken } from "../../../store/reducers/tokenSlice";
 import { likePost, unlikePost } from "../../../store/reducers/likeSlice";
 import Toast from "../../Toast";
@@ -23,12 +22,11 @@ export interface IconContainerProps {
         userImage: string;
       };
     }[];
-    comments: CommentData[];
   };
 }
 
 const Icons: React.FC<IconContainerProps> = ({ iconsProps }) => {
-  const { postId, likedUser, comments } = iconsProps;
+  const { postId, likedUser } = iconsProps;
   const dispatch = useDispatch<ThunkDispatch<any, any, any>>();
   const user = useSelector(selectUser);
   const token = useSelector(selectAccessToken);
@@ -75,7 +73,7 @@ const Icons: React.FC<IconContainerProps> = ({ iconsProps }) => {
       {isToastVisible && <Toast toastProps={{ path: "user" }} />}
       {isModalVisible && (
         <Modal onClose={handleCloseModal} modalRef={modalRef}>
-          <CommentsContainer comments={comments} />
+          <CommentsContainer postId={postId} />
           {user && <CommentForm postId={postId} />}
         </Modal>
       )}

--- a/frontend/src/Components/Post/PostContainer/index.tsx
+++ b/frontend/src/Components/Post/PostContainer/index.tsx
@@ -16,7 +16,6 @@ export interface PostContainerProps {
 const PostContainer: React.FC<PostContainerProps> = ({ post }) => {
   const {
     commentCount,
-    comments,
     createdAt,
     updatedAt,
     image,
@@ -31,10 +30,10 @@ const PostContainer: React.FC<PostContainerProps> = ({ post }) => {
     <Styled.PostContainer>
       <Author authorProps={{ postId, author: User }} />
       <Image image={image} />
-      <Icons iconsProps={{ postId, likedUser, comments }} />
+      <Icons iconsProps={{ postId, likedUser }} />
       <Like likeProps={{ likeCount, likedUser }} />
       <Text text={text} />
-      <Comments commentsProps={{ postId, commentCount, comments }} />
+      <Comments commentsProps={{ postId, commentCount }} />
       <PostDate createdAt={createdAt} />
     </Styled.PostContainer>
   );

--- a/frontend/src/Components/Post/PostGrid/index.tsx
+++ b/frontend/src/Components/Post/PostGrid/index.tsx
@@ -19,7 +19,7 @@ const PostGrid: React.FC<PostContainerProps> = ({ posts }) => {
             </Styled.PostLikeCount>
             <Styled.CommentIcon />
             <Styled.PostCommentCount>
-              {post?.comments?.length || 0}
+              {post?.commentCount || 0}
             </Styled.PostCommentCount>
           </Styled.PostHover>
         </Styled.HoverContainer>

--- a/frontend/src/Components/Toast/index.tsx
+++ b/frontend/src/Components/Toast/index.tsx
@@ -2,9 +2,9 @@ import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch } from "@reduxjs/toolkit";
-import { fetchPostById, deletePost } from "../../store/reducers/postSlice";
+import { deletePost } from "../../store/reducers/postSlice";
 import { logout } from "../../store/reducers/userSlice";
-import { fetchComments , deleteComment } from "../../store/reducers/commentSlice";
+import { fetchCommentsByPostId , deleteComment } from "../../store/reducers/commentSlice";
 import { selectAccessToken, removeAccessToken } from "../../store/reducers/tokenSlice";
 import Styled from "./index.styles";
 import {
@@ -59,8 +59,7 @@ const Toast: React.FC<ToastProps> = ({ toastProps }) => {
       (await dispatch(
         deleteComment({ commentId, token: accessToken })
       ));
-    postId && (await dispatch(fetchPostById(postId)));
-    postId && (await dispatch(fetchComments(postId)));
+    postId && (await dispatch(fetchCommentsByPostId(postId)));
   };
 
   const handleLogoutClick = async () => {

--- a/frontend/src/pages/EditForm/index.tsx
+++ b/frontend/src/pages/EditForm/index.tsx
@@ -10,7 +10,7 @@ import {
   selectError,
   updatePost,
 } from "../../store/reducers/postSlice";
-import { fetchComments } from "../../store/reducers/commentSlice";
+import { fetchCommentsByPostId } from "../../store/reducers/commentSlice";
 import { selectAccessToken } from "../../store/reducers/tokenSlice";
 import Loading from "../../Components/Loading";
 
@@ -26,7 +26,7 @@ const EditForm: React.FC = () => {
 
   useEffect(() => {
     dispatch(fetchPostById(parseInt(postId)));
-    dispatch(fetchComments(parseInt(postId)));
+    dispatch(fetchCommentsByPostId(parseInt(postId)));
   }, [dispatch, postId]);
 
   const [text, setText] = useState<string>(post?.text || "");

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -3,15 +3,11 @@ import { useSelector, useDispatch } from "react-redux";
 import { ThunkDispatch } from "@reduxjs/toolkit";
 import Styled from "./index.styles";
 import {
-  Post as PostData,
   fetchPosts,
   selectPosts,
   selectIsLoading,
-  selectError,
 } from "../../store/reducers/postSlice";
 import PostsContainer from "../../Components/Post/PostsContainer";
-import CommentsContainer from "../../Components/Comment/CommentsContainer";
-import Modal from "../../Components/Modal";
 import Loading from "../../Components/Loading";
 
 const Home = () => {
@@ -30,7 +26,7 @@ const Home = () => {
 
   return (
     <Styled.MainContainer>
-      <PostsContainer posts={posts}></PostsContainer>
+      <PostsContainer posts={posts} />
     </Styled.MainContainer>
   );
 };

--- a/frontend/src/pages/Post/index.tsx
+++ b/frontend/src/pages/Post/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../store/reducers/postSlice";
 import Styled from "./index.styles";
 import PostContainer from "../../Components/Post/PostContainer";
-import { fetchComments } from "../../store/reducers/commentSlice";
+import { fetchCommentsByPostId } from "../../store/reducers/commentSlice";
 
 const Post = () => {
   const { postId } = useParams() as { postId: string };
@@ -20,7 +20,7 @@ const Post = () => {
 
   useEffect(() => {
     dispatch(fetchPostById(parseInt(postId)));
-    dispatch(fetchComments(parseInt(postId)));
+    dispatch(fetchCommentsByPostId(parseInt(postId)));
   }, [dispatch, postId]);
 
   if (error) {

--- a/frontend/src/store/reducers/commentSlice.ts
+++ b/frontend/src/store/reducers/commentSlice.ts
@@ -48,11 +48,11 @@ export interface DeleteCommentPayload {
   token: string | null;
 }
 
-export const fetchComments = createAsyncThunk(
+export const fetchCommentsByPostId = createAsyncThunk(
   "comment/fetchComments",
   async (postId: number) => {
     try {
-      const response = await axios.get(`/api/comment?postId=${postId}`);
+      const response = await axios.get(`/api/comment/${postId}`);
       return response.data as Comment[];
     } catch (error) {
       throw Error("Failed to fetch comments");
@@ -105,15 +105,15 @@ const commentSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
-      .addCase(fetchComments.pending, (state) => {
+      .addCase(fetchCommentsByPostId.pending, (state) => {
         state.loading = true;
         state.error = null;
       })
-      .addCase(fetchComments.fulfilled, (state, action) => {
+      .addCase(fetchCommentsByPostId.fulfilled, (state, action) => {
         state.loading = false;
         state.comments = action.payload;
       })
-      .addCase(fetchComments.rejected, (state, action) => {
+      .addCase(fetchCommentsByPostId.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error?.message || "";
       })
@@ -121,9 +121,8 @@ const commentSlice = createSlice({
         state.loading = true;
         state.error = null;
       })
-      .addCase(createComment.fulfilled, (state, action) => {
+      .addCase(createComment.fulfilled, (state) => {
         state.loading = false;
-        state.comments.push(action.payload);
       })
       .addCase(createComment.rejected, (state, action) => {
         state.loading = false;

--- a/frontend/src/store/reducers/postSlice.ts
+++ b/frontend/src/store/reducers/postSlice.ts
@@ -8,7 +8,6 @@ import {
 } from "@reduxjs/toolkit";
 import axios from "axios";
 import { RootState } from "../store";
-import { Comment } from "./commentSlice";
 
 export interface Post {
   postId: number;
@@ -22,7 +21,6 @@ export interface Post {
   createdAt: Date;
   updatedAt: Date;
   commentCount: number;
-  comments: Comment[];
   likeCount: number;
   likedUser: {
     userId: number;


### PR DESCRIPTION
1. 기존에는 댓글을 게시물과의 관계를 통해 fetch 했지만 이로 인해, 게시물에 댓글을 달거나, 삭제하거나, 댓글에 좋아요를 누른 후 댓글의 상태를 업데이트하기 위해 게시물 전체를 fetch 해와야 했음. 이를 post와 comment를 따로 fetch 하도록 분리 후, 댓글을 달거나, 삭제하거나, 댓글에 좋아요를 누른 후, comment만 fetch 하게 변경함. 이로 인해 게시물 전체를 fetch 하지 않아도 되기 때문에 네트워크 비용도 감소되고 댓글 Modal 창이 켜진 채로 유지돼서 사용자 경험을 개선함