### PR TITLE
Fix: 사용자가 로그아웃을 할 때 accessToken 삭제를 2번 시도하는 오류 수정

### DIFF
--- a/backend/controllers/search.controller.js
+++ b/backend/controllers/search.controller.js
@@ -34,10 +34,11 @@ const searchUsersAndPosts = async (req, res) => {
         {
           model: Follower,
           as: "followers",
-          attributes: ["followerId"],
+          attributes: ["followingId"],
           include: [
             {
               model: User,
+              as: "follower",
               attributes: ["userId", "userName", "userImage"],
             },
           ],
@@ -45,10 +46,11 @@ const searchUsersAndPosts = async (req, res) => {
         {
           model: Follower,
           as: "followings",
-          attributes: ["followingId"],
+          attributes: ["followerId"],
           include: [
             {
               model: User,
+              as: "following",
               attributes: ["userId", "userName", "userImage"],
             },
           ],

--- a/backend/controllers/search.controller.js
+++ b/backend/controllers/search.controller.js
@@ -34,7 +34,7 @@ const searchUsersAndPosts = async (req, res) => {
         {
           model: Follower,
           as: "followers",
-          attributes: ["followingId"],
+          attributes: ["followerId"],
           include: [
             {
               model: User,
@@ -46,7 +46,7 @@ const searchUsersAndPosts = async (req, res) => {
         {
           model: Follower,
           as: "followings",
-          attributes: ["followerId"],
+          attributes: ["followingId"],
           include: [
             {
               model: User,

--- a/backend/controllers/token.controller.js
+++ b/backend/controllers/token.controller.js
@@ -61,6 +61,7 @@ const refreshAccessToken = async (req, res) => {
 
     // 리프레시 토큰이 만료되었는지 검사
     if (new Date().getTime() > token.refreshTokenExpireAt.getTime()) {
+      await Token.destroy({ where: { refreshToken } });
       return res.status(401).json({ error: "만료된 리프레시 토큰입니다." });
     }
 
@@ -84,10 +85,6 @@ const removeAccessToken = async (req, res) => {
     const userId = req.session.userId;
 
     // 해당 사용자의 토큰 정보를 데이터베이스에서 삭제
-    console.log("efefeefeefeef");
-    console.log("efefeefeefeef");
-    console.log("efefeefeefeef");
-    console.log("efefeefeefeef");
     const deletedTokenCount = await Token.destroy({ where: { userId } });
 
     if (deletedTokenCount > 0) {

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -136,7 +136,7 @@ const login = async (req, res) => {
         {
           model: Follower,
           as: "followers",
-          attributes: ["followingId"],
+          attributes: ["followerId"],
           include: [
             {
               model: User,
@@ -148,7 +148,7 @@ const login = async (req, res) => {
         {
           model: Follower,
           as: "followings",
-          attributes: ["followerId"],
+          attributes: ["followingId"],
           include: [
             {
               model: User,
@@ -197,7 +197,7 @@ const getUser = async (req, res) => {
         {
           model: Follower,
           as: "followers",
-          attributes: ["followingId"],
+          attributes: ["followerId"],
           include: [
             {
               model: User,
@@ -209,7 +209,7 @@ const getUser = async (req, res) => {
         {
           model: Follower,
           as: "followings",
-          attributes: ["followerId"],
+          attributes: ["followingId"],
           include: [
             {
               model: User,
@@ -256,7 +256,7 @@ const getUsersBatch = async (req, res) => {
         {
           model: Follower,
           as: "followers",
-          attributes: ["followingId"],
+          attributes: ["followerId"],
           include: [
             {
               model: User,
@@ -268,7 +268,7 @@ const getUsersBatch = async (req, res) => {
         {
           model: Follower,
           as: "followings",
-          attributes: ["followerId"],
+          attributes: ["followingId"],
           include: [
             {
               model: User,

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -120,10 +120,47 @@ const login = async (req, res) => {
 
     req.session.userId = user.userId;
 
-    const { userId, email: userEmail, userName, userImage } = user;
-    const userInfo = { userId, email: userEmail, userName, userImage };
+    const userFullInfo = await User.findByPk(user.userId, {
+      attributes: ["userId", "userName", "userImage"],
+      include: [
+        {
+          model: Post,
+          as: "posts",
+          include: [
+            {
+              model: Comment,
+              as: "comments",
+            },
+          ],
+        },
+        {
+          model: Follower,
+          as: "followers",
+          attributes: ["followingId"],
+          include: [
+            {
+              model: User,
+              as: "follower",
+              attributes: ["userId", "userName", "userImage"],
+            },
+          ],
+        },
+        {
+          model: Follower,
+          as: "followings",
+          attributes: ["followerId"],
+          include: [
+            {
+              model: User,
+              as: "following",
+              attributes: ["userId", "userName", "userImage"],
+            },
+          ],
+        },
+      ],
+    });
 
-    res.status(200).json({ user: userInfo });
+    res.status(200).json({ user: userFullInfo });
   } catch (error) {
     res.status(500).json({ error: "Server error" });
   }
@@ -160,10 +197,11 @@ const getUser = async (req, res) => {
         {
           model: Follower,
           as: "followers",
-          attributes: ["followerId"],
+          attributes: ["followingId"],
           include: [
             {
               model: User,
+              as: "follower",
               attributes: ["userId", "userName", "userImage"],
             },
           ],
@@ -171,10 +209,11 @@ const getUser = async (req, res) => {
         {
           model: Follower,
           as: "followings",
-          attributes: ["followingId"],
+          attributes: ["followerId"],
           include: [
             {
               model: User,
+              as: "following",
               attributes: ["userId", "userName", "userImage"],
             },
           ],
@@ -217,10 +256,11 @@ const getUsersBatch = async (req, res) => {
         {
           model: Follower,
           as: "followers",
-          attributes: ["followerId"],
+          attributes: ["followingId"],
           include: [
             {
               model: User,
+              as: "follower",
               attributes: ["userId", "userName", "userImage"],
             },
           ],
@@ -228,10 +268,11 @@ const getUsersBatch = async (req, res) => {
         {
           model: Follower,
           as: "followings",
-          attributes: ["followingId"],
+          attributes: ["followerId"],
           include: [
             {
               model: User,
+              as: "following",
               attributes: ["userId", "userName", "userImage"],
             },
           ],

--- a/backend/models/model.js
+++ b/backend/models/model.js
@@ -343,10 +343,17 @@ User.hasMany(Follower, {
   sourceKey: "userId",
   as: "followers",
 });
+// Follower.belongsTo(User, {
+//   foreignKey: "followerId",
+//   targetKey: "userId",
+//   as: "follower",
+// });
 Follower.belongsTo(User, {
-  foreignKey: "followerId",
+  foreignKey: "followingId",
   targetKey: "userId",
+  as: "follower",
 });
+
 
 User.hasMany(Follower, {
   foreignKey: "followingId",
@@ -354,9 +361,15 @@ User.hasMany(Follower, {
   as: "followings",
 });
 Follower.belongsTo(User, {
-  foreignKey: "followingId",
+  foreignKey: "followerId",
   targetKey: "userId",
+  as: "following",
 });
+// Follower.belongsTo(User, {
+//   foreignKey: "followingId",
+//   targetKey: "userId",
+//   as: "following",
+// });
 
 ChatRoom.hasMany(ChatUser, {
   foreignKey: 'roomId',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,6 @@ const App: React.FC = () => {
       }
     } else {
       // 액세스 토큰이 없는 경우 로그아웃
-      dispatch(removeAccessToken());
       dispatch(logout());
     }
   }, [accessToken, refreshToken, dispatch]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch } from "@reduxjs/toolkit";
 import {
   refreshAccessToken,
+  removeAccessToken,
   selectAccessToken,
   selectRefreshToken,
 } from "./store/reducers/tokenSlice";
@@ -38,6 +39,7 @@ const App: React.FC = () => {
       if (accessTokenExp && accessTokenExp < Date.now() / 1000) {
         // 리프레시 토큰이 없을 경우 로그아웃
         if (!refreshToken) {
+          dispatch(removeAccessToken());
           dispatch(logout());
           return;
         }
@@ -47,6 +49,7 @@ const App: React.FC = () => {
       }
     } else {
       // 액세스 토큰이 없는 경우 로그아웃
+      dispatch(removeAccessToken());
       dispatch(logout());
     }
   }, [accessToken, refreshToken, dispatch]);

--- a/frontend/src/Components/Navigation/index.tsx
+++ b/frontend/src/Components/Navigation/index.tsx
@@ -16,7 +16,7 @@ const Navigation = () => {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
 
   useEffect(() => {
-    setIsLoggedIn(accessToken !== null);
+    setIsLoggedIn(!!accessToken);
   }, [accessToken]);
 
   const handleToProfile = () => {

--- a/frontend/src/Components/User/UserCard/index.tsx
+++ b/frontend/src/Components/User/UserCard/index.tsx
@@ -4,8 +4,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch, AnyAction } from "@reduxjs/toolkit";
 import Styled from "./index.styles";
 import {
-  User,
   selectUser,
+  getLoggedinUserInfo,
   getUserInfo,
 } from "../../../store/reducers/userSlice";
 import { Post } from "../../../store/reducers/postSlice";
@@ -21,7 +21,7 @@ export interface UserCardProps {
     userImage: string;
     posts?: Post[];
     followings?: {
-      followerId: number;
+      followingId: number;
       following: {
         userId: number;
         userName: string;
@@ -29,7 +29,7 @@ export interface UserCardProps {
       };
     }[];
     followers?: {
-      followingId: number;
+      followerId: number;
       follower: {
         userId: number;
         userName: string;
@@ -61,18 +61,22 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
       );
   }, [user, loggedinUser]);
 
+  console.log(loggedinUser)
+
   const handleFollow = async () => {
-    if (user && userId) {
+    if (user && loggedinUser && userId) {
       // 현재 사용자가 이미 해당 사용자를 팔로우하고 있는지 확인합니다.
       if (isFollowing) {
         // 이미 팔로우 중인 경우 언팔로우를 실행합니다.
         await dispatch(unfollowUser({ followerId: userId, token }));
+        await dispatch(getLoggedinUserInfo(loggedinUser.userId));
         await dispatch(getUserInfo(userId));
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(false);
       } else {
         // 팔로우하지 않은 경우 팔로우를 실행합니다.
         await dispatch(followUser({ followerId: userId, token }));
+        await dispatch(getLoggedinUserInfo(loggedinUser.userId));
         await dispatch(getUserInfo(userId));
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(true);

--- a/frontend/src/Components/User/UserCard/index.tsx
+++ b/frontend/src/Components/User/UserCard/index.tsx
@@ -8,12 +8,35 @@ import {
   selectUser,
   getUserInfo,
 } from "../../../store/reducers/userSlice";
+import { Post } from "../../../store/reducers/postSlice";
 import { followUser, unfollowUser } from "../../../store/reducers/followSlice";
 import { selectAccessToken } from "../../../store/reducers/tokenSlice";
 import { createNewChatRoom } from "../../../store/reducers/chatSlice";
 
 export interface UserCardProps {
-  user: User;
+  user: {
+    userId: number;
+    email?: string;
+    userName: string;
+    userImage: string;
+    posts?: Post[];
+    followings?: {
+      followerId: number;
+      following: {
+        userId: number;
+        userName: string;
+        userImage: string;
+      };
+    }[];
+    followers?: {
+      followingId: number;
+      follower: {
+        userId: number;
+        userName: string;
+        userImage: string;
+      };
+    }[];
+  };
 }
 
 const UserCard: React.FC<UserCardProps> = ({ user }) => {
@@ -30,10 +53,10 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
   };
 
   useEffect(() => {
-    user &&
+    loggedinUser?.followings &&
       setIsFollowing(
-        user?.followers.some(
-          (follower) => follower.User.userId === loggedinUser?.userId
+        loggedinUser?.followings.some(
+          (following) => following.following.userId === userId
         )
       );
   }, [user, loggedinUser]);
@@ -43,13 +66,13 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
       // 현재 사용자가 이미 해당 사용자를 팔로우하고 있는지 확인합니다.
       if (isFollowing) {
         // 이미 팔로우 중인 경우 언팔로우를 실행합니다.
-        await dispatch(unfollowUser({ followerId: user.userId, token }));
+        await dispatch(unfollowUser({ followerId: userId, token }));
         await dispatch(getUserInfo(userId));
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(false);
       } else {
         // 팔로우하지 않은 경우 팔로우를 실행합니다.
-        await dispatch(followUser({ followerId: user.userId, token }));
+        await dispatch(followUser({ followerId: userId, token }));
         await dispatch(getUserInfo(userId));
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(true);
@@ -62,7 +85,7 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
       loggedinUser &&
         createNewChatRoom({
           userId: loggedinUser.userId,
-          partnerId: user.userId,
+          partnerId: userId,
         })
     )) as unknown;
     if (response && (response as AnyAction).payload) {
@@ -72,12 +95,12 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
   };
 
   return (
-    <Styled.UserCard key={user.userId}>
+    <Styled.UserCard key={userId}>
       <Styled.UserDiv onClick={() => handleUserClick(userId)}>
-        <Styled.UserImage src={user.userImage} alt="User Profile" />
-        <Styled.UserName>{user.userName}</Styled.UserName>
+        <Styled.UserImage src={userImage} alt="User Profile" />
+        <Styled.UserName>{userName}</Styled.UserName>
       </Styled.UserDiv>
-      {loggedinUser && loggedinUser?.userId !== user.userId && (
+      {loggedinUser && loggedinUser?.userId !== userId && (
         <Styled.ButtonsContainer>
           {!isFollowing ? (
             <Styled.FollowButton onClick={handleFollow}>

--- a/frontend/src/Components/User/UserCard/index.tsx
+++ b/frontend/src/Components/User/UserCard/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch, AnyAction } from "@reduxjs/toolkit";
 import Styled from "./index.styles";
@@ -43,6 +43,7 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
   const { userId, email, userName, userImage, posts, followings, followers } =
     user;
   const navigate = useNavigate();
+  const { userId: profileUserId } = useParams<{ userId: string }>();
   const dispatch = useDispatch<ThunkDispatch<any, any, any>>();
   const loggedinUser = useSelector(selectUser);
   const token = useSelector(selectAccessToken);
@@ -61,8 +62,6 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
       );
   }, [user, loggedinUser]);
 
-  console.log(loggedinUser)
-
   const handleFollow = async () => {
     if (user && loggedinUser && userId) {
       // 현재 사용자가 이미 해당 사용자를 팔로우하고 있는지 확인합니다.
@@ -70,14 +69,18 @@ const UserCard: React.FC<UserCardProps> = ({ user }) => {
         // 이미 팔로우 중인 경우 언팔로우를 실행합니다.
         await dispatch(unfollowUser({ followerId: userId, token }));
         await dispatch(getLoggedinUserInfo(loggedinUser.userId));
-        await dispatch(getUserInfo(userId));
+        if (profileUserId && parseInt(profileUserId) === loggedinUser.userId) {
+          await dispatch(getUserInfo(loggedinUser.userId));
+        }
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(false);
       } else {
         // 팔로우하지 않은 경우 팔로우를 실행합니다.
         await dispatch(followUser({ followerId: userId, token }));
         await dispatch(getLoggedinUserInfo(loggedinUser.userId));
-        await dispatch(getUserInfo(userId));
+        if (profileUserId && parseInt(profileUserId) === loggedinUser.userId) {
+          await dispatch(getUserInfo(loggedinUser.userId));
+        }
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(true);
       }

--- a/frontend/src/Components/User/UserContainer/index.tsx
+++ b/frontend/src/Components/User/UserContainer/index.tsx
@@ -55,6 +55,7 @@ const UserContainer: React.FC<UserContainerProps> = ({
     if (userId !== undefined) {
       dispatch(getUserInfo(parseInt(userId)));
     }
+    setActiveTab("posts");
   }, [userId]);
 
   useEffect(() => {

--- a/frontend/src/Components/User/UserContainer/index.tsx
+++ b/frontend/src/Components/User/UserContainer/index.tsx
@@ -40,6 +40,13 @@ const UserContainer: React.FC<UserContainerProps> = ({
   const isLoading = useSelector(selectIsLoading);
   const token = useSelector(selectAccessToken);
   const [isFollowing, setIsFollowing] = useState<boolean>(false);
+  const [activeTab, setActiveTab] = useState<
+    "posts" | "followings" | "followers"
+    >("posts");
+  
+  const handleTabChange = (tab: "posts" | "followings" | "followers") => {
+    setActiveTab(tab);
+  };
 
   useEffect(() => {
     // 사용자 정보와 사용자가 작성한 포스트 정보를 가져오는 액션 호출
@@ -104,15 +111,19 @@ const UserContainer: React.FC<UserContainerProps> = ({
           </Styled.MenuContainer>
           <Styled.UserProfileContainer>
             <Styled.UserImage src={user.userImage} alt="Profile" />
-            <Styled.UserStatContainer>
+            <Styled.UserStatContainer onClick={() => handleTabChange("posts")}>
               <Styled.UserStat>{"게시물"}</Styled.UserStat>
               <Styled.UserStat>{user.posts.length}</Styled.UserStat>
             </Styled.UserStatContainer>
-            <Styled.UserStatContainer>
+            <Styled.UserStatContainer
+              onClick={() => handleTabChange("followings")}
+            >
               <Styled.UserStat>{"팔로잉"}</Styled.UserStat>
               <Styled.UserStat>{user.followings?.length || 0}</Styled.UserStat>
             </Styled.UserStatContainer>
-            <Styled.UserStatContainer>
+            <Styled.UserStatContainer
+              onClick={() => handleTabChange("followers")}
+            >
               <Styled.UserStat>{"팔로워"}</Styled.UserStat>
               <Styled.UserStat>{user.followers?.length || 0}</Styled.UserStat>
             </Styled.UserStatContainer>

--- a/frontend/src/Components/User/UserContainer/index.tsx
+++ b/frontend/src/Components/User/UserContainer/index.tsx
@@ -19,6 +19,7 @@ import { GiHamburgerMenu } from "react-icons/gi";
 import PostGrid from "../../Post/PostGrid";
 import Toast from "../../Toast";
 import Loading from "../../Loading";
+import UserCard from "../UserCard";
 
 export interface UserContainerProps {
   userContainerProps: {
@@ -56,10 +57,11 @@ const UserContainer: React.FC<UserContainerProps> = ({
   }, [userId]);
 
   useEffect(() => {
-    user &&
+    loggedinUser &&
+      userId &&
       setIsFollowing(
-        user?.followers.some(
-          (follower) => follower.User.userId === loggedinUser?.userId
+        loggedinUser?.followings.some(
+          (following) => following.following.userId === parseInt(userId)
         )
       );
   }, [user, loggedinUser]);
@@ -144,9 +146,25 @@ const UserContainer: React.FC<UserContainerProps> = ({
               </Styled.MessageButton>
             </Styled.ButtonsContainer>
           )}
-          <Styled.PostsContainer>
-            <PostGrid posts={user?.posts} />
-          </Styled.PostsContainer>
+          {activeTab === "posts" && (
+            <Styled.PostsContainer>
+              <PostGrid posts={user?.posts} />
+            </Styled.PostsContainer>
+          )}
+          {activeTab === "followings" && (
+            <Styled.PostsContainer>
+              {user?.followings?.map((user) => (
+                <UserCard user={user.following} key={user.following.userId} />
+              ))}
+            </Styled.PostsContainer>
+          )}
+          {activeTab === "followers" && (
+            <Styled.PostsContainer>
+              {user?.followers?.map((user) => (
+                <UserCard user={user.follower} key={user.follower.userId} />
+              ))}
+            </Styled.PostsContainer>
+          )}
           {isToastVisible && <Toast toastProps={{ path: "user" }} />}
         </>
       ) : (

--- a/frontend/src/Components/User/UserContainer/index.tsx
+++ b/frontend/src/Components/User/UserContainer/index.tsx
@@ -5,6 +5,7 @@ import { ThunkDispatch, AnyAction } from "@reduxjs/toolkit";
 import {
   selectUser,
   selectUserOnProfile,
+  getLoggedinUserInfo,
   getUserInfo,
   selectIsLoading,
 } from "../../../store/reducers/userSlice";
@@ -57,7 +58,7 @@ const UserContainer: React.FC<UserContainerProps> = ({
   }, [userId]);
 
   useEffect(() => {
-    loggedinUser &&
+    loggedinUser?.followings &&
       userId &&
       setIsFollowing(
         loggedinUser?.followings.some(
@@ -67,17 +68,19 @@ const UserContainer: React.FC<UserContainerProps> = ({
   }, [user, loggedinUser]);
 
   const handleFollow = async () => {
-    if (user && userId) {
+    if (user && loggedinUser && userId) {
       // 현재 사용자가 이미 해당 사용자를 팔로우하고 있는지 확인합니다.
       if (isFollowing) {
         // 이미 팔로우 중인 경우 언팔로우를 실행합니다.
         await dispatch(unfollowUser({ followerId: user.userId, token }));
+        await dispatch(getLoggedinUserInfo(loggedinUser.userId));
         await dispatch(getUserInfo(parseInt(userId)));
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(false);
       } else {
         // 팔로우하지 않은 경우 팔로우를 실행합니다.
         await dispatch(followUser({ followerId: user.userId, token }));
+        await dispatch(getLoggedinUserInfo(loggedinUser.userId));
         await dispatch(getUserInfo(parseInt(userId)));
         // 팔로우 또는 언팔로우 후 isFollowing 상태 업데이트
         setIsFollowing(true);

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { ThunkDispatch } from "@reduxjs/toolkit";
 import Styled from "./index.styles";
-import { login, userActions, selectUser, selectError } from "../../store/reducers/userSlice";
+import { login, userActions, selectUser, selectIsLoading, selectError } from "../../store/reducers/userSlice";
 import { issueAccessToken } from "../../store/reducers/tokenSlice";
 
 const Login = () => {
@@ -13,11 +13,12 @@ const Login = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const user = useSelector(selectUser);
+  const loading = useSelector(selectIsLoading);
   const error = useSelector(selectError);
 
   useEffect(() => {
     user && navigate("/");
-  }, []);
+  }, [user]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/pages/Search/index.styles.tsx
+++ b/frontend/src/pages/Search/index.styles.tsx
@@ -84,19 +84,6 @@ const SearchResults = styled.div`
 
 `;
 
-const UserCard = styled.div`
-  display: flex;
-  align-items: center;
-  width: 500px;
-  padding: 8px;
-  border-radius: 8px;
-  margin-top: 8px;
-  cursor: pointer;
-  &:hover {
-    background-color: #f0f0f0;
-  }
-`;
-
 const UserImage = styled.img`
   width: 40px;
   height: 40px;
@@ -131,7 +118,6 @@ export default {
   PostsTab,
   TabButton,
   SearchResults,
-  UserCard,
   UserImage,
   UserName,
   TextContainer,

--- a/frontend/src/pages/Signup/index.tsx
+++ b/frontend/src/pages/Signup/index.tsx
@@ -39,7 +39,7 @@ const Signup = () => {
 
   useEffect(() => {
     user && navigate("/");
-  }, []);
+  }, [user]);
 
   useEffect(() => {
     if (error) {

--- a/frontend/src/store/reducers/userSlice.ts
+++ b/frontend/src/store/reducers/userSlice.ts
@@ -10,7 +10,7 @@ export interface User {
   userImage: string;
   posts: Post[];
   followings: {
-    followerId: number;
+    followingId: number;
     following: {
       userId: number;
       userName: string;
@@ -18,7 +18,7 @@ export interface User {
     };
   }[];
   followers: {
-    followingId: number;
+    followerId: number;
     follower: {
       userId: number;
       userName: string;
@@ -91,6 +91,19 @@ export const login = createAsyncThunk(
 export const logout = createAsyncThunk("user/logout", async () => {
   return;
 });
+
+export const getLoggedinUserInfo = createAsyncThunk(
+  "user/getLoggedinUserInfo",
+  async (userId: number) => {
+    try {
+      const response = await axios.get(`/api/user/${userId}`);
+
+      return response.data;
+    } catch (error) {
+      throw Error("Failed to get user info");
+    }
+  }
+);
 
 export const getUserInfo = createAsyncThunk(
   "user/getUserInfo",
@@ -176,6 +189,18 @@ const userSlice = createSlice({
         state.user = null;
       })
       .addCase(logout.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error?.message || "";
+      })
+      .addCase(getLoggedinUserInfo.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(getLoggedinUserInfo.fulfilled, (state, action) => {
+        state.loading = false;
+        state.user = action.payload;
+      })
+      .addCase(getLoggedinUserInfo.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error?.message || "";
       })

--- a/frontend/src/store/reducers/userSlice.ts
+++ b/frontend/src/store/reducers/userSlice.ts
@@ -10,16 +10,16 @@ export interface User {
   userImage: string;
   posts: Post[];
   followings: {
-    followingId: number;
-    User: {
+    followerId: number;
+    following: {
       userId: number;
       userName: string;
       userImage: string;
     };
   }[];
   followers: {
-    followerId: number;
-    User: {
+    followingId: number;
+    follower: {
       userId: number;
       userName: string;
       userImage: string;


### PR DESCRIPTION
1. 로그인 성공시 메인 페이지로 리다이렉션 하지 않는 현상 수정
2. 토큰 만료로 인해 자동 로그아웃 됐을 시 Navigation 컴포넌트에서 isLoggedIn 상태 변경이 제대로 되지 않는 현상 수정
3. 리프레시 토큰이 만료됐을 때 db에서 해당 레코드 삭제하게 수정
4. User 페이지에서 게시물, 팔로잉, 팔로워 탭을 클릭시 변경되는 activeTab 상태 추가
5. User 페이지에서 팔로잉, 팔로워 탭을 클릭하면 해당 유저들을 보여주는 기능 구현
6. 팔로우, 언팔로우 기능이 제대로 동작하지 않는 현상 수정
7. 팔로우, 언팔로우 상태 잘못 표시되는 현상 수정
8. 다른 사용자 페이지 방문시 항상 posts 목록이 먼저 나오도록 수정
9. 다른 유저를 팔로잉 했는지 판별할 때, 상대방의 팔로워 목록에서 로그인한 유저를 체크하는 방식에서, 로그인한 유저의 팔로잉 목록에서 상대방이 있는지 체크하도록 로직 변경
10. 유저 페이지에서 다른 사용자를 팔로우, 언팔로우 했을 때 팔로잉 수에 변화가 없던 현상 수정
11. 다른 사용자 페이지 방문시 항상 posts 목록이 먼저 나오도록 수정
12. 사용자가 로그아웃을 할 때 accessToken 삭제를 2번 시도하는 오류 수정